### PR TITLE
Add a convenient link to the job being triggered on the remote server

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -547,6 +547,8 @@ public class RemoteBuildConfiguration extends Builder {
         //Have to form the string ourselves, as we might not get a response from non-parameterized builds
         String jobURL = remoteServerURL + "/job/" + this.encodeValue(job) + "/";
 
+        listener.getLogger().println("Triggering " + jobURL + Integer.toString(nextBuildNumber));
+
         // This is only for Debug
         // This output whether there is another job running on the remote host that this job had conflicted with.
         // The first condition is what is expected, The second is what would happen if two jobs launched jobs at the


### PR DESCRIPTION
In full disclosure, I haven't tested this all that much so a solid code review is much appreciated.