### PR TITLE
Fixed so user can choose how many connection retries to make

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -58,7 +58,7 @@ public class RemoteBuildConfiguration extends Builder {
 
     private final boolean         shouldNotFailBuild;
     private final int             pollInterval;
-    private final int             connectionRetryLimit = 5;
+    private final int             connectionRetryLimit;
     private final boolean         preventRemoteBuildQueue;
     private final boolean         blockBuildUntilComplete;
     private final boolean         enhancedLogging;
@@ -85,7 +85,7 @@ public class RemoteBuildConfiguration extends Builder {
     @DataBoundConstructor
     public RemoteBuildConfiguration(String remoteJenkinsName, boolean shouldNotFailBuild, String job, String token,
             String parameters, boolean enhancedLogging, JSONObject overrideAuth, JSONObject loadParamsFromFile, boolean preventRemoteBuildQueue,
-            boolean blockBuildUntilComplete, int pollInterval) throws MalformedURLException {
+            boolean blockBuildUntilComplete, int pollInterval, int connectionRetryLimit) throws MalformedURLException {
 
         this.token = token.trim();
         this.remoteJenkinsName = remoteJenkinsName;
@@ -94,6 +94,7 @@ public class RemoteBuildConfiguration extends Builder {
         this.preventRemoteBuildQueue = preventRemoteBuildQueue;
         this.blockBuildUntilComplete = blockBuildUntilComplete;
         this.pollInterval = pollInterval;
+        this.connectionRetryLimit = connectionRetryLimit;
         this.enhancedLogging = enhancedLogging;
 
         if (overrideAuth != null && overrideAuth.has("auth")) {
@@ -127,7 +128,7 @@ public class RemoteBuildConfiguration extends Builder {
     }
 
     public RemoteBuildConfiguration(String remoteJenkinsName, boolean shouldNotFailBuild,
-            boolean preventRemoteBuildQueue, boolean blockBuildUntilComplete, int pollInterval, String job,
+            boolean preventRemoteBuildQueue, boolean blockBuildUntilComplete, int pollInterval, int connectionRetryLimit, String job,
             String token, String parameters, boolean enhancedLogging) throws MalformedURLException {
 
         this.token = token.trim();
@@ -139,6 +140,7 @@ public class RemoteBuildConfiguration extends Builder {
         this.preventRemoteBuildQueue = preventRemoteBuildQueue;
         this.blockBuildUntilComplete = blockBuildUntilComplete;
         this.pollInterval = pollInterval;
+        this.connectionRetryLimit = connectionRetryLimit;
         this.overrideAuth = false;
         this.auth.replaceBy(new Auth(null));
 

--- a/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration/config.jelly
@@ -24,6 +24,10 @@
   <f:entry title="Poll Interval (seconds)" field="pollInterval">
      <f:number clazz="positive-number" min="1" step="1" default="10" />
   </f:entry>
+  
+  <f:entry title="Maximum number of retries" field="connectionRetryLimit">
+     <f:number clazz="positive-number" min="0" step="1" default="5" />
+  </f:entry>  
 
   <f:entry title="Block until the remote triggered projects finish their builds." field="blockBuildUntilComplete">
     <f:checkbox />

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
@@ -31,7 +31,7 @@ public class RemoteBuildConfigurationTest {
         FreeStyleProject project = jenkinsRule.createFreeStyleProject();
         RemoteBuildConfiguration remoteBuildConfiguration = new RemoteBuildConfiguration(
                 remoteJenkinsServer.getDisplayName(), false, remoteProject.getFullName(), "",
-                "", true, null, null, false, true, 1);
+                "", true, null, null, false, true, 1, 5);
         project.getBuildersList().add(remoteBuildConfiguration);
 
         jenkinsRule.buildAndAssertSuccess(project);


### PR DESCRIPTION
To give user more control, i think they should be able to choose how many retries to make - not only 5.
My builds take a long time to process, and i would like to update more often.

Thanks for the nice plugin!