### PR TITLE
Add support for triggering remote jobs defined in folder structure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
 
   <artifactId>Parameterized-Remote-Trigger</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.3-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Parameterized Remote Trigger Plugin</name>
   <description>This plugin gives you the ability to trigger parameterized builds on a remote Jenkins server as part of your build.</description>

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -1055,6 +1055,9 @@ public class RemoteBuildConfiguration extends Builder {
 
         try {
             cleanValue = URLEncoder.encode(dirtyValue, "UTF-8").replace("+", "%20");
+
+            // jobs might be defined in folders and referenced as {host}/job/[job-name-containing-folder-and-slash]
+            cleanValue = cleanValue.replace("%2F", "/");
         } catch (UnsupportedEncodingException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();


### PR DESCRIPTION
Jenkins jobs might be defined in folders as well as in views but current version of the remote trigger plugin only supports jobs defined in views.

When defined in views, jobs can be referenced in two ways:
- {host}/view/{view-name}/job/{job-name} (this syntax cannot be used with the plugin)
- {host}/job/{job-name} (this is OK for the plugin)

However, when defined in folders, jobs can only be referenced like:
- {host}/job/{folder-name}/job/{job-name} (cannot be recognized by current version of the plugin)

This PR fixes the latter scenario so remote trigger plugin can be used with remote jobs defined in folder structure.
