### PR TITLE
Fix of HTTP errors, other than 404.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -972,6 +972,9 @@ public class RemoteBuildConfiguration extends Builder {
             InputStream is;
             try {
                 is = connection.getInputStream();
+                if (is == null) { // when other than 404 error, ex. 401, or 500
+                	is = connection.getErrorStream();
+                }
             } catch (FileNotFoundException e) {
                 // In case of a e.g. 404 status
                 is = connection.getErrorStream();


### PR DESCRIPTION
See issue described at https://issues.jenkins-ci.org/browse/JENKINS-47919
Probably new version of Jenkins returns other than 404 when the job is beeing started, unfortunately I cannot reproduce it from my test case, but with plugin deployed on jenkins error occurs sometimes (not each time, but sometimes).